### PR TITLE
Add ChatGPT Deep Research support with dual MCP architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,33 @@
 
 A Model Context Protocol (MCP) server that provides AI assistants with comprehensive access to WordPress.org Trac data. Built with TypeScript and deployed on Cloudflare Workers.
 
+**🆕 Now with ChatGPT Deep Research support!**
+
 ## Overview
 
-This MCP server transforms WordPress Trac into an AI-accessible knowledge base, enabling intelligent queries about WordPress development, ticket tracking, and code changes.
+This MCP server transforms WordPress Trac into an AI-accessible knowledge base, enabling intelligent queries about WordPress development, ticket tracking, and code changes. Features dual architecture supporting both standard MCP clients and ChatGPT's Deep Research requirements.
 
 ## Features
 
+- **Dual Architecture**: Standard MCP + ChatGPT Deep Research support
 - Search 60,000+ WordPress tickets by keywords, components, or status
 - Get detailed ticket information including descriptions, status, and metadata
 - Access changeset information with full diff content
 - Monitor recent WordPress development activity
 - Retrieve project metadata like components, milestones, and priorities
+- **Intelligent Query Routing**: Automatically detects ticket numbers, revisions, and keywords
+- **Smart Caching**: Optimizes fetch operations for better performance
 - WordPress-branded UI with official styling
 
 ## Available Tools
 
-### searchTickets
+The server provides two different tool interfaces depending on your client:
+
+### Standard MCP Tools
+
+For Claude Desktop, MCP Inspector, and other standard MCP clients:
+
+#### searchTickets
 Search through WordPress Trac tickets with intelligent filtering.
 
 ```json
@@ -31,7 +42,7 @@ Search through WordPress Trac tickets with intelligent filtering.
 }
 ```
 
-### getTicket
+#### getTicket
 Retrieve comprehensive information about specific tickets.
 
 ```json
@@ -44,7 +55,7 @@ Retrieve comprehensive information about specific tickets.
 }
 ```
 
-### getChangeset
+#### getChangeset
 Access detailed information about code commits and changes.
 
 ```json
@@ -58,7 +69,7 @@ Access detailed information about code commits and changes.
 }
 ```
 
-### getTimeline
+#### getTimeline
 Monitor recent WordPress development activity.
 
 ```json
@@ -71,7 +82,7 @@ Monitor recent WordPress development activity.
 }
 ```
 
-### getTracInfo
+#### getTracInfo
 Get organizational data like components and milestones.
 
 ```json
@@ -82,6 +93,45 @@ Get organizational data like components and milestones.
   }
 }
 ```
+
+### ChatGPT Deep Research Tools
+
+For ChatGPT's Deep Research feature (simplified interface):
+
+#### search
+Intelligent search that automatically routes to the right data based on your query.
+
+```json
+{
+  "tool": "search",
+  "args": {
+    "query": "block editor performance"
+  }
+}
+```
+
+**Supported query types:**
+- **Keywords**: `"REST API bugs"`, `"media upload issues"`
+- **Ticket numbers**: `"#61234"`, `"61234"`  
+- **Changesets**: `"r58504"`, `"58504"`
+- **Recent activity**: `"recent"`, `"timeline"`, `"latest"`
+- **Components**: `"Block Editor"`, `"REST API"`
+
+#### fetch
+Get detailed information about a specific item by ID.
+
+```json
+{
+  "tool": "fetch",
+  "args": {
+    "id": "61234"
+  }
+}
+```
+
+**Supported ID formats:**
+- Ticket IDs: `"61234"`
+- Changeset revisions: `"r58504"`
 
 ## Installation
 
@@ -104,6 +154,8 @@ npm run deploy
 
 ### Connect to AI Assistant
 
+#### Standard MCP (Claude Desktop, etc.)
+
 Add to your `claude_desktop_config.json`:
 
 ```json
@@ -116,6 +168,22 @@ Add to your `claude_desktop_config.json`:
   }
 }
 ```
+
+#### ChatGPT Deep Research
+
+ChatGPT uses a different connection method than Claude Desktop. Follow these steps:
+
+1. **Open ChatGPT Settings** → Go to the **Connectors** tab
+2. **Add Server** → Import your remote MCP server directly:
+   ```
+   https://your-worker-url/mcp/chatgpt
+   ```
+3. **Enable in Composer** → The server will appear in **Composer** > **Deep Research** tool
+4. **Add as Source** → You may need to manually add the server as a research source
+
+For detailed setup instructions, see: [ChatGPT MCP Documentation](https://platform.openai.com/docs/mcp#connect-in-chatgpt)
+
+> **Note**: ChatGPT requires exactly 2 tools (`search` and `fetch`) with simplified schemas. The `/mcp/chatgpt` endpoint is specifically optimized for this requirement.
 
 ## Development
 


### PR DESCRIPTION
- Implement /mcp/chatgpt endpoint with OpenAI-compliant search and fetch tools
- Add intelligent query routing for ticket numbers, revisions, and keywords
- Enable in-memory caching for optimized fetch operations
- Update landing page with proper ChatGPT setup instructions (UI-based)
- Maintain full backward compatibility with existing standard MCP endpoint
- Follow OpenAI MCP specification exactly: simplified tools, OpenAI response format

🤖 Generated with [Claude Code](https://claude.ai/code)